### PR TITLE
fixed issue 3 'Unable to resolve the request "notes/noteconfig/index"'

### DIFF
--- a/controllers/NoteConfigController.php
+++ b/controllers/NoteConfigController.php
@@ -55,7 +55,7 @@ class NoteConfigController extends Controller {
                 $form->apiKey = HSetting::Set('apiKey', $form->apiKey, 'notes');
 
 #                $this->redirect(Yii::app()->createUrl('admin/manageModules'));
-                $this->redirect(Yii::app()->createUrl('notes/noteconfig/index'));
+                $this->redirect(Yii::app()->createUrl('notes/noteConfig/index'));
             }
         } else {
             $form->baseUrl = HSetting::Get('baseUrl', 'notes');


### PR DESCRIPTION
FIxed this issue:https://github.com/humhub/humhub-modules-notes/issues/3
It was caused by incorrect name "noteconfig". The correct name is "noteConfig".