### PR TITLE
Update NoteController.php

### DIFF
--- a/controllers/NoteController.php
+++ b/controllers/NoteController.php
@@ -30,6 +30,7 @@ class NoteController extends ContentContainerController
         return array(
             'stream' => array(
                 'class' => StreamAction::className(),
+                'includes' => Note::className(),
                 'mode' => StreamAction::MODE_NORMAL,
                 'contentContainer' => $this->contentContainer
             ),


### PR DESCRIPTION
Solves a bug : if you sort by date creation, when you click on the button "show more" to see others notes, it will search others notes older than the last note shown.
But if you post a comment on an old note and sort by updates, if this commented note is just before the "show more" button, it will show only notes older than this one. But as it is an old one, the notes before are not shown !
This commit solves the problem