### PR TITLE
Fix: make old namespace migration resilient to evolved activity table schema

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,6 +3,7 @@ Changelog
 
 0.13.3 (Unreleased)
 -------------------------
+- Fix: Make m150726_182212_namespace migration resilient to evolved schema (activity.module column no longer exists)
 - Fix #49: Fix asset bundle
 - Fix #50: Remove deprecations
 

--- a/migrations/m150726_182212_namespace.php
+++ b/migrations/m150726_182212_namespace.php
@@ -12,10 +12,9 @@ class m150726_182212_namespace extends Migration
         $this->delete('notification', ['class' => 'NoteCreatedNotification']);
         $this->delete('notification', ['class' => 'NoteUpdatedNotification']);
 
-        foreach (\humhub\modules\activity\models\Activity::findAll(['module' => 'notes']) as $activity) {
-            $activity->delete();
+        if ($this->columnExists('module', 'activity')) {
+            $this->execute("DELETE FROM activity WHERE module = 'notes'");
         }
-
     }
 
     public function down()
@@ -24,15 +23,4 @@ class m150726_182212_namespace extends Migration
 
         return false;
     }
-
-    /*
-      // Use safeUp/safeDown to run migration code within a transaction
-      public function safeUp()
-      {
-      }
-
-      public function safeDown()
-      {
-      }
-     */
 }


### PR DESCRIPTION
The 2015 migration `m150726_182212_namespace` used `Activity::findAll(['module' => 'notes'])` to delete old activity records. The `module` column no longer exists in the `activity` table, causing a fresh module install (or re-install after disable) to fail with:

```
Key "module" is not a column name and can not be used as a filter
```

Fix: use `columnExists()` before querying. If the column is gone, the data doesn't exist either, so the step is safely skipped.